### PR TITLE
Fix eval error after nixpkgs license refactoring

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,7 @@
 
       findLicense = spdxId:
         (findFirst (x:
-          if (hasAttr "spdxId" x.value) then
+          if (isAttrs x.value && hasAttr "spdxId" x.value) then
             x.value.spdxId == spdxId
           else
             false) { value = licenses.unfree; }


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/468378 refactored `nixpkgs.lib.licenses` to include a few functions, which break the `findLicense` function.

Fix by filtering out entries that are not attrsets.